### PR TITLE
Fix object URL cleanup

### DIFF
--- a/src/components/ImageList.tsx
+++ b/src/components/ImageList.tsx
@@ -23,10 +23,12 @@ const ImageItem = ({ image }: { image: ConvertImage }) => {
   const handleDownload = () => {
     if (image.status !== 'done') return;
 
+    const url = URL.createObjectURL(image.result);
     const a = document.createElement('a');
-    a.href = URL.createObjectURL(image.result);
+    a.href = url;
     a.download = image.outputFilename;
     a.click();
+    URL.revokeObjectURL(url);
   };
 
   return (

--- a/src/components/ResultBar.tsx
+++ b/src/components/ResultBar.tsx
@@ -26,10 +26,12 @@ export const ResultBar = ({ className }: ResultBarProps) => {
       }
     }
     const blob = await zip.generateAsync({ type: 'blob' });
+    const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
+    a.href = url;
     a.download = 'images.zip';
     a.click();
+    URL.revokeObjectURL(url);
   }, [images]);
 
   return (


### PR DESCRIPTION
## Summary
- ensure temporary object URLs are cleaned up in `ImageList` and `ResultBar`

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68406b935da483328318ab6a631d7a8a