### PR TITLE
Add file size display

### DIFF
--- a/src/__tests__/components.test.tsx
+++ b/src/__tests__/components.test.tsx
@@ -36,6 +36,8 @@ describe('components render', () => {
       status: 'done',
       filename: 'foo.png',
       outputFilename: 'foo.png',
+      originalSize: 8,
+      compressedSize: 4,
       result: new File(['data'], 'foo.png', { type: 'image/png' }),
     };
 

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { generateOutputFilename } from '../components/InputImageArea';
+import { formatFileSize } from '../utils';
 
 describe('generateOutputFilename', () => {
   it('returns same filename when type is auto', () => {
@@ -8,5 +9,13 @@ describe('generateOutputFilename', () => {
 
   it('replaces extension based on type', () => {
     expect(generateOutputFilename('foo.png', 'image/jpeg')).toBe('foo.jpeg');
+  });
+});
+
+describe('formatFileSize', () => {
+  it('formats bytes to KB and MB', () => {
+    expect(formatFileSize(500)).toBe('500 B');
+    expect(formatFileSize(2048)).toBe('2.0 KB');
+    expect(formatFileSize(5 * 1024 * 1024)).toBe('5.0 MB');
   });
 });

--- a/src/components/ImageList.tsx
+++ b/src/components/ImageList.tsx
@@ -1,5 +1,5 @@
 import { type ConvertImage, useImages } from '../hooks';
-import { cx } from '../utils';
+import { cx, formatFileSize } from '../utils';
 
 export interface ImageListProps {
   className?: string;
@@ -47,7 +47,13 @@ const ImageItem = ({ image }: { image: ConvertImage }) => {
           {image.status === 'done' && '完了'}
           {image.status === 'error' && 'エラー'}
         </span>
-        <span className="w-4/6">{image.filename}</span>
+        <span className="w-4/6">
+          {image.filename}
+          <span className="block text-xs mt-1">
+            {formatFileSize(image.originalSize)}
+            {image.status === 'done' && ` → ${formatFileSize(image.compressedSize)}`}
+          </span>
+        </span>
       </div>
       <div>
         <button

--- a/src/components/ImageList.tsx
+++ b/src/components/ImageList.tsx
@@ -33,26 +33,24 @@ const ImageItem = ({ image }: { image: ConvertImage }) => {
   };
 
   return (
-    <li className="flex justify-between items-center p-2 bg-slate-700 border border-gray-600 text-white">
-      <div>
-        <span
-          className={cx(
-            'text-white px-2 py-1 rounded mr-4 text-sm',
-            image.status === 'converting' && 'bg-yellow-600',
-            image.status === 'done' && 'bg-slate-500',
-            image.status === 'error' && 'bg-red-600',
-          )}
-        >
-          {image.status === 'converting' && '変換中...'}
-          {image.status === 'done' && '完了'}
-          {image.status === 'error' && 'エラー'}
-        </span>
-        <span className="w-4/6">
-          {image.filename}
-          <span className="block text-xs mt-1">
-            {formatFileSize(image.originalSize)}
-            {image.status === 'done' && ` → ${formatFileSize(image.compressedSize)}`}
-          </span>
+    <li className="flex justify-between items-start p-2 bg-slate-700 border border-gray-600 text-white">
+      <span
+        className={cx(
+          'text-white px-2 py-1 rounded mr-4 text-sm shrink-0',
+          image.status === 'converting' && 'bg-yellow-600',
+          image.status === 'done' && 'bg-slate-500',
+          image.status === 'error' && 'bg-red-600',
+        )}
+      >
+        {image.status === 'converting' && '変換中...'}
+        {image.status === 'done' && '完了'}
+        {image.status === 'error' && 'エラー'}
+      </span>
+      <div className="flex-1">
+        <span>{image.filename}</span>
+        <span className="block text-xs mt-1">
+          {formatFileSize(image.originalSize)}
+          {image.status === 'done' && ` → ${formatFileSize(image.compressedSize)}`}
         </span>
       </div>
       <div>

--- a/src/components/InputImageArea.tsx
+++ b/src/components/InputImageArea.tsx
@@ -28,6 +28,7 @@ export const InputImageArea = ({ className }: InputImageAreaProps) => {
             status: 'converting',
             filename: fileInfo.path,
             outputFilename: generateOutputFilename(fileInfo.path, convertFileType),
+            originalSize: fileInfo.file.size,
           };
           addImage(convertImage);
 
@@ -53,6 +54,7 @@ export const InputImageArea = ({ className }: InputImageAreaProps) => {
               ...convertImage,
               status: 'done',
               result: file,
+              compressedSize: file.size,
             });
           })
           .catch((error) => {

--- a/src/hooks/useImages.ts
+++ b/src/hooks/useImages.ts
@@ -6,6 +6,7 @@ interface ConvertImageBase {
   id: string;
   filename: string;
   outputFilename: string;
+  originalSize: number;
 }
 
 export interface ConvertImageConverting extends ConvertImageBase {
@@ -15,6 +16,7 @@ export interface ConvertImageConverting extends ConvertImageBase {
 export interface ConvertImageDone extends ConvertImageBase {
   status: 'done';
   result: File;
+  compressedSize: number;
 }
 
 export interface ConvertImageError extends ConvertImageBase {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,9 @@
 export const cx = (...classes: (string | false | undefined | null)[]) => {
   return classes.filter(Boolean).join(' ');
 };
+
+export const formatFileSize = (size: number) => {
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  return `${(size / 1024 / 1024).toFixed(1)} MB`;
+};


### PR DESCRIPTION
## Summary
- track original and compressed file sizes for images
- show the sizes in the image list
- provide a helper to format file sizes
- test formatting helper

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6842eb6ee53883329a53126a88e8e332