### PR TITLE
Add thumbnail column for images

### DIFF
--- a/src/__tests__/components.test.tsx
+++ b/src/__tests__/components.test.tsx
@@ -60,4 +60,27 @@ describe('components render', () => {
       expect(screen.queryByText('foo.png')).not.toBeInTheDocument();
     });
   });
+
+  it('shows thumbnail when conversion is done', async () => {
+    const image: ConvertImageDone = {
+      id: '1',
+      status: 'done',
+      filename: 'foo.png',
+      outputFilename: 'foo.png',
+      originalSize: 8,
+      compressedSize: 4,
+      result: new File(['data'], 'foo.png', { type: 'image/png' }),
+    };
+
+    const Setup: React.FC = () => {
+      const { addImage } = useImages();
+      useEffect(() => {
+        addImage(image);
+      }, [addImage]);
+      return <ImageList />;
+    };
+
+    render(<Setup />, { wrapper });
+    expect(await screen.findByAltText('foo.png')).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/components.test.tsx
+++ b/src/__tests__/components.test.tsx
@@ -81,6 +81,8 @@ describe('components render', () => {
     };
 
     render(<Setup />, { wrapper });
-    expect(await screen.findByAltText('foo.png')).toBeInTheDocument();
+    const img = await screen.findByAltText('foo.png');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveClass('bg-white');
   });
 });

--- a/src/components/ImageList.tsx
+++ b/src/components/ImageList.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo } from 'react';
 import { type ConvertImage, useImages } from '../hooks';
 import { cx, formatFileSize } from '../utils';
 
@@ -32,6 +33,17 @@ const ImageItem = ({ image }: { image: ConvertImage }) => {
     URL.revokeObjectURL(url);
   };
 
+  const thumbnailUrl = useMemo(() => {
+    if (image.status !== 'done') return '';
+    return URL.createObjectURL(image.result);
+  }, [image]);
+
+  useEffect(() => {
+    return () => {
+      if (thumbnailUrl) URL.revokeObjectURL(thumbnailUrl);
+    };
+  }, [thumbnailUrl]);
+
   return (
     <li className="flex justify-between items-start p-2 bg-slate-700 border border-gray-600 text-white">
       <span
@@ -46,6 +58,11 @@ const ImageItem = ({ image }: { image: ConvertImage }) => {
         {image.status === 'done' && '完了'}
         {image.status === 'error' && 'エラー'}
       </span>
+      {image.status === 'done' ? (
+        <img src={thumbnailUrl} alt={image.filename} className="w-16 h-16 object-contain mr-4 rounded" />
+      ) : (
+        <div className="w-16 h-16 mr-4" />
+      )}
       <div className="flex-1">
         <span>{image.filename}</span>
         <span className="block text-xs mt-1">

--- a/src/components/ImageList.tsx
+++ b/src/components/ImageList.tsx
@@ -59,7 +59,7 @@ const ImageItem = ({ image }: { image: ConvertImage }) => {
         {image.status === 'error' && 'エラー'}
       </span>
       {image.status === 'done' ? (
-        <img src={thumbnailUrl} alt={image.filename} className="w-16 h-16 object-contain mr-4 rounded" />
+        <img src={thumbnailUrl} alt={image.filename} className="w-16 h-16 object-contain mr-4 rounded bg-white" />
       ) : (
         <div className="w-16 h-16 mr-4" />
       )}

--- a/src/hooks/useImages.ts
+++ b/src/hooks/useImages.ts
@@ -1,4 +1,5 @@
 import { atom, useAtom } from 'jotai';
+import { useCallback } from 'react';
 
 export type ConvertImage = ConvertImageConverting | ConvertImageDone | ConvertImageError;
 
@@ -29,24 +30,33 @@ const imagesAtom = atom<ConvertImage[]>([]);
 export const useImages = () => {
   const [images, setImages] = useAtom(imagesAtom);
 
-  const addImage = (image: ConvertImage) => {
-    setImages((images) => {
-      if (images.some((i) => i.id === image.id)) {
-        return images.map((i) => (i.id === image.id ? image : i));
-      }
-      return [...images, image];
-    });
-  };
+  const addImage = useCallback(
+    (image: ConvertImage) => {
+      setImages((images) => {
+        if (images.some((i) => i.id === image.id)) {
+          return images.map((i) => (i.id === image.id ? image : i));
+        }
+        return [...images, image];
+      });
+    },
+    [setImages],
+  );
 
-  const updateImage = (id: string, image: ConvertImage) => {
-    setImages((images) => {
-      return images.map((i) => (i.id === id ? image : i));
-    });
-  };
+  const updateImage = useCallback(
+    (id: string, image: ConvertImage) => {
+      setImages((images) => {
+        return images.map((i) => (i.id === id ? image : i));
+      });
+    },
+    [setImages],
+  );
 
-  const removeImage = (id: string) => {
-    setImages((images) => images.filter((i) => i.id !== id));
-  };
+  const removeImage = useCallback(
+    (id: string) => {
+      setImages((images) => images.filter((i) => i.id !== id));
+    },
+    [setImages],
+  );
 
   return {
     images,

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,17 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+// jsdom does not implement createObjectURL
+// https://github.com/jsdom/jsdom/issues/1721
+if (!('createObjectURL' in URL)) {
+  Object.defineProperty(URL, 'createObjectURL', {
+    writable: true,
+    configurable: true,
+    value: vi.fn(),
+  });
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    writable: true,
+    configurable: true,
+    value: vi.fn(),
+  });
+}


### PR DESCRIPTION
## Summary
- show thumbnail in converted list between status and filename
- test for thumbnail rendering
- polyfill `URL.createObjectURL` for Vitest

## Testing
- `pnpm lint`
- `pnpm test` *(fails: only utils tests run before process stalls)*

------
https://chatgpt.com/codex/tasks/task_e_6842eeb6e5a88332a4ae592aca1fbba6