### PR TITLE
Show converted image format

### DIFF
--- a/src/components/ImageList.tsx
+++ b/src/components/ImageList.tsx
@@ -2,6 +2,19 @@ import { useEffect, useMemo } from 'react';
 import { type ConvertImage, useImages } from '../hooks';
 import { cx, formatFileSize } from '../utils';
 
+function fileTypeLabel(type: string) {
+  switch (type) {
+    case 'image/jpeg':
+      return 'JPEG';
+    case 'image/png':
+      return 'PNG';
+    case 'image/webp':
+      return 'WebP';
+    default:
+      return type;
+  }
+}
+
 export interface ImageListProps {
   className?: string;
 }
@@ -69,6 +82,11 @@ const ImageItem = ({ image }: { image: ConvertImage }) => {
           {formatFileSize(image.originalSize)}
           {image.status === 'done' && ` → ${formatFileSize(image.compressedSize)}`}
         </span>
+        {image.status === 'done' && (
+          <span className="block text-xs mt-1" data-testid="converted-file-type">
+            形式: {fileTypeLabel(image.convertedFileType)}
+          </span>
+        )}
       </div>
       <div>
         <button

--- a/src/components/InputImageArea.tsx
+++ b/src/components/InputImageArea.tsx
@@ -55,6 +55,7 @@ export const InputImageArea = ({ className }: InputImageAreaProps) => {
               status: 'done',
               result: file,
               compressedSize: file.size,
+              convertedFileType: file.type,
             });
           })
           .catch((error) => {

--- a/src/components/__tests__/ImageList.test.tsx
+++ b/src/components/__tests__/ImageList.test.tsx
@@ -22,6 +22,7 @@ describe('ImageList', () => {
       originalSize: 8,
       compressedSize: 4,
       result: new File(['data'], 'foo.png', { type: 'image/png' }),
+      convertedFileType: 'image/png',
     };
 
     const Setup: React.FC = () => {
@@ -53,6 +54,7 @@ describe('ImageList', () => {
       originalSize: 8,
       compressedSize: 4,
       result: new File(['data'], 'foo.png', { type: 'image/png' }),
+      convertedFileType: 'image/png',
     };
 
     const Setup: React.FC = () => {
@@ -67,5 +69,30 @@ describe('ImageList', () => {
     const img = await screen.findByAltText('foo.png');
     expect(img).toBeInTheDocument();
     expect(img).toHaveClass('bg-white');
+  });
+
+  it('displays converted file type', async () => {
+    const image: ConvertImageDone = {
+      id: '1',
+      status: 'done',
+      filename: 'foo.png',
+      outputFilename: 'foo.png',
+      originalSize: 8,
+      compressedSize: 4,
+      result: new File(['data'], 'foo.png', { type: 'image/png' }),
+      convertedFileType: 'image/png',
+    };
+
+    const Setup: React.FC = () => {
+      const { addImage } = useImages();
+      useEffect(() => {
+        addImage(image);
+      }, [addImage]);
+      return <ImageList />;
+    };
+
+    render(<Setup />, { wrapper });
+    const label = await screen.findByTestId('converted-file-type');
+    expect(label).toHaveTextContent('PNG');
   });
 });

--- a/src/hooks/useImages.ts
+++ b/src/hooks/useImages.ts
@@ -18,6 +18,7 @@ export interface ConvertImageDone extends ConvertImageBase {
   status: 'done';
   result: File;
   compressedSize: number;
+  convertedFileType: string;
 }
 
 export interface ConvertImageError extends ConvertImageBase {


### PR DESCRIPTION
## Summary
- track converted image file type
- display conversion format in each image item
- test format display

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_6843325d9e0c83328a820c21368b2deb