### PR TITLE
Add image modal

### DIFF
--- a/src/components/ImageList.tsx
+++ b/src/components/ImageList.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { type ConvertImage, useImages } from '../hooks';
 import { cx, formatFileSize } from '../utils';
+import { ImageModal } from './ImageModal';
 
 function fileTypeLabel(type: string) {
   switch (type) {
@@ -35,6 +36,7 @@ export const ImageList = ({ className }: ImageListProps) => {
 
 const ImageItem = ({ image }: { image: ConvertImage }) => {
   const { removeImage } = useImages();
+  const [open, setOpen] = useState(false);
   const handleDownload = () => {
     if (image.status !== 'done') return;
 
@@ -72,7 +74,19 @@ const ImageItem = ({ image }: { image: ConvertImage }) => {
         {image.status === 'error' && 'エラー'}
       </span>
       {image.status === 'done' ? (
-        <img src={thumbnailUrl} alt={image.filename} className="w-16 h-16 object-contain mr-4 rounded bg-white" />
+        <>
+          <button
+            type="button"
+            className="w-16 h-16 mr-4 rounded bg-white cursor-pointer p-0"
+            onClick={() => setOpen(true)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') setOpen(true);
+            }}
+          >
+            <img src={thumbnailUrl} alt={image.filename} className="w-full h-full object-contain" />
+          </button>
+          <ImageModal open={open} src={thumbnailUrl} alt={image.filename} onClose={() => setOpen(false)} />
+        </>
       ) : (
         <div className="w-16 h-16 mr-4" />
       )}

--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -25,19 +25,19 @@ export const ImageModal = ({ open, src, alt, onClose }: ImageModalProps) => {
     <button
       type="button"
       data-testid="image-modal"
-      className="ImageModal fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-80"
+      className="ImageModal fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-80 overflow-auto"
       onClick={onClose}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') onClose();
       }}
     >
-      <div
+      <img
+        src={src}
+        alt={alt}
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => e.stopPropagation()}
-        className="max-h-[90vh] max-w-[90vw]"
-      >
-        <img src={src} alt={alt} className="object-contain max-h-full max-w-full" />
-      </div>
+        className="object-contain max-h-[90vh] max-w-[90vw]"
+      />
     </button>
   );
 };

--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -31,8 +31,12 @@ export const ImageModal = ({ open, src, alt, onClose }: ImageModalProps) => {
         if (e.key === 'Enter' || e.key === ' ') onClose();
       }}
     >
-      <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
-        <img src={src} alt={alt} className="max-w-full max-h-full" />
+      <div
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+        className="max-h-[90vh] max-w-[90vw]"
+      >
+        <img src={src} alt={alt} className="object-contain max-h-full max-w-full" />
       </div>
     </button>
   );

--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+
+export interface ImageModalProps {
+  open: boolean;
+  src: string;
+  alt: string;
+  onClose: () => void;
+}
+
+export const ImageModal = ({ open, src, alt, onClose }: ImageModalProps) => {
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <button
+      type="button"
+      data-testid="image-modal"
+      className="ImageModal fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-80"
+      onClick={onClose}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') onClose();
+      }}
+    >
+      <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+        <img src={src} alt={alt} className="max-w-full max-h-full" />
+      </div>
+    </button>
+  );
+};

--- a/src/components/__tests__/ImageList.test.tsx
+++ b/src/components/__tests__/ImageList.test.tsx
@@ -68,7 +68,33 @@ describe('ImageList', () => {
     render(<Setup />, { wrapper });
     const img = await screen.findByAltText('foo.png');
     expect(img).toBeInTheDocument();
-    expect(img).toHaveClass('bg-white');
+    expect(img.parentElement).toHaveClass('bg-white');
+  });
+
+  it('opens modal when thumbnail clicked', async () => {
+    const image: ConvertImageDone = {
+      id: '1',
+      status: 'done',
+      filename: 'foo.png',
+      outputFilename: 'foo.png',
+      originalSize: 8,
+      compressedSize: 4,
+      result: new File(['data'], 'foo.png', { type: 'image/png' }),
+      convertedFileType: 'image/png',
+    };
+
+    const Setup: React.FC = () => {
+      const { addImage } = useImages();
+      useEffect(() => {
+        addImage(image);
+      }, [addImage]);
+      return <ImageList />;
+    };
+
+    render(<Setup />, { wrapper });
+    const img = await screen.findByAltText('foo.png');
+    fireEvent.click(img);
+    expect(await screen.findByTestId('image-modal')).toBeInTheDocument();
   });
 
   it('displays converted file type', async () => {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,3 +2,4 @@ export * from './ConvertImageFileTypeSelector';
 export * from './ImageList';
 export * from './InputImageArea';
 export * from './ResultBar';
+export * from './ImageModal';


### PR DESCRIPTION
## Summary
- open a modal to preview converted images by clicking thumbnails
- allow closing the modal and update tests

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_6843348d674483328655948bff1c313a