### PR TITLE
Add clear converted images feature

### DIFF
--- a/src/components/ResultBar.tsx
+++ b/src/components/ResultBar.tsx
@@ -8,7 +8,7 @@ export interface ResultBarProps {
 }
 
 export const ResultBar = ({ className }: ResultBarProps) => {
-  const { images } = useImages();
+  const { images, removeDoneImages } = useImages();
 
   const convertedCount = useMemo(() => {
     return images.filter((image) => image.status === 'done').length;
@@ -34,6 +34,10 @@ export const ResultBar = ({ className }: ResultBarProps) => {
     URL.revokeObjectURL(url);
   }, [images]);
 
+  const handleClear = useCallback(() => {
+    removeDoneImages();
+  }, [removeDoneImages]);
+
   return (
     <div
       data-testid="result-bar"
@@ -55,6 +59,14 @@ export const ResultBar = ({ className }: ResultBarProps) => {
             disabled={convertedCount === 0 || convertedCount !== imagesWithoutErrorCount}
           >
             ZIPでダウンロード
+          </button>
+          <button
+            type="button"
+            className="px-4 py-2 ml-4 bg-red-500 text-white rounded"
+            onClick={handleClear}
+            disabled={convertedCount === 0}
+          >
+            すべて削除
           </button>
         </div>
       </div>

--- a/src/components/ResultBar.tsx
+++ b/src/components/ResultBar.tsx
@@ -8,7 +8,7 @@ export interface ResultBarProps {
 }
 
 export const ResultBar = ({ className }: ResultBarProps) => {
-  const { images, removeDoneImages } = useImages();
+  const { images, removeProcessedImages } = useImages();
 
   const convertedCount = useMemo(() => {
     return images.filter((image) => image.status === 'done').length;
@@ -34,9 +34,13 @@ export const ResultBar = ({ className }: ResultBarProps) => {
     URL.revokeObjectURL(url);
   }, [images]);
 
+  const clearableCount = useMemo(() => {
+    return images.filter((image) => image.status === 'done' || image.status === 'error').length;
+  }, [images]);
+
   const handleClear = useCallback(() => {
-    removeDoneImages();
-  }, [removeDoneImages]);
+    removeProcessedImages();
+  }, [removeProcessedImages]);
 
   return (
     <div
@@ -62,9 +66,9 @@ export const ResultBar = ({ className }: ResultBarProps) => {
           </button>
           <button
             type="button"
-            className="px-4 py-2 ml-4 bg-red-500 text-white rounded"
+            className="px-4 py-2 ml-4 bg-red-500 text-white rounded disabled:cursor-not-allowed disabled:opacity-30 disabled:bg-gray-400"
             onClick={handleClear}
-            disabled={convertedCount === 0}
+            disabled={clearableCount === 0}
           >
             すべて削除
           </button>

--- a/src/components/__tests__/ResultBar.test.tsx
+++ b/src/components/__tests__/ResultBar.test.tsx
@@ -1,8 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'jotai';
 import type React from 'react';
+import { useEffect } from 'react';
 import { describe, expect, it } from 'vitest';
 import { ResultBar } from '../';
+import { type ConvertImageDone, useImages } from '../../hooks';
 
 const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => <Provider>{children}</Provider>;
 
@@ -10,5 +12,37 @@ describe('ResultBar', () => {
   it('renders', () => {
     render(<ResultBar />, { wrapper });
     expect(screen.getByTestId('result-bar')).toBeInTheDocument();
+  });
+
+  it('clear button removes all converted images', async () => {
+    const image: ConvertImageDone = {
+      id: '1',
+      status: 'done',
+      filename: 'foo.png',
+      outputFilename: 'foo.png',
+      originalSize: 8,
+      compressedSize: 4,
+      result: new File(['data'], 'foo.png', { type: 'image/png' }),
+      convertedFileType: 'image/png',
+    };
+
+    const Setup: React.FC = () => {
+      const { addImage } = useImages();
+      useEffect(() => {
+        addImage(image);
+      }, [addImage]);
+      return <ResultBar />;
+    };
+
+    render(<Setup />, { wrapper });
+
+    expect(await screen.findByText('変換済み: 1 / 1')).toBeInTheDocument();
+
+    const clearButton = screen.getByRole('button', { name: 'すべて削除' });
+    fireEvent.click(clearButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('変換済み: 0 / 0')).toBeInTheDocument();
+    });
   });
 });

--- a/src/hooks/useImages.ts
+++ b/src/hooks/useImages.ts
@@ -59,8 +59,8 @@ export const useImages = () => {
     [setImages],
   );
 
-  const removeDoneImages = useCallback(() => {
-    setImages((images) => images.filter((i) => i.status !== 'done'));
+  const removeProcessedImages = useCallback(() => {
+    setImages((images) => images.filter((i) => i.status === 'converting'));
   }, [setImages]);
 
   return {
@@ -69,6 +69,6 @@ export const useImages = () => {
     addImage,
     updateImage,
     removeImage,
-    removeDoneImages,
+    removeProcessedImages,
   };
 };

--- a/src/hooks/useImages.ts
+++ b/src/hooks/useImages.ts
@@ -59,11 +59,16 @@ export const useImages = () => {
     [setImages],
   );
 
+  const removeDoneImages = useCallback(() => {
+    setImages((images) => images.filter((i) => i.status !== 'done'));
+  }, [setImages]);
+
   return {
     images,
     setImages,
     addImage,
     updateImage,
     removeImage,
+    removeDoneImages,
   };
 };


### PR DESCRIPTION
## Summary
- allow clearing all converted images from state
- add 'すべて削除' button in ResultBar
- test clearing converted images

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_684334069730833283fe27ba38863765